### PR TITLE
User Story 12

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -10,7 +10,7 @@ class FavoritesController < ApplicationController
     pet = Pet.find(params[:pet_id])
     favorite.add_pet(pet.id)
     session[:favorite] = favorite.contents
-    flash[:notice] = "#{pet.name} has been added to your favorites."   
+    flash[:notice] = "#{pet.name} has been added to your favorites"   
 
     redirect_to "/pets/#{pet.id}"
   end
@@ -18,7 +18,7 @@ class FavoritesController < ApplicationController
   def destroy
     pet = Pet.find(params[:pet_id])
     favorite.contents.delete(pet.id.to_s)
-    flash[:notice] = "#{pet.name} has been removed from your favorites."   
+    flash[:notice] = "#{pet.name} has been removed from your favorites"   
 
     redirect_to "/pets/#{pet.id}"
   end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -14,4 +14,13 @@ class FavoritesController < ApplicationController
 
     redirect_to "/pets/#{pet.id}"
   end
+
+  def destroy
+    pet = Pet.find(params[:pet_id])
+    favorite.contents.delete(pet.id.to_s)
+    flash[:notice] = "#{pet.name} has been removed from your favorites."   
+
+    redirect_to "/pets/#{pet.id}"
+  end
+  
 end

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -1,4 +1,5 @@
 class PetsController < ApplicationController
+  include ActionView::Helpers::TextHelper
 
   def index
     @pets = Pet.all
@@ -34,6 +35,7 @@ class PetsController < ApplicationController
 
   def destroy
     Pet.destroy(params[:pet_id])
+    favorite.contents.delete(params[:pet_id])
 
     redirect_to "/pets/"
   end

--- a/app/views/pets/show.html.erb
+++ b/app/views/pets/show.html.erb
@@ -16,7 +16,11 @@
         <p>Adoption Status: <%= @pet.adoption_status %></p>
         <%= link_to "Update Pet", "/pets/#{@pet.id}/edit" %>
         <%= button_to "Delete Pet", "/pets/#{@pet.id}", method: :delete %>
-        <%= button_to "Add Pet to Favorites", "/favorites/#{@pet.id}", method: :patch %> 
+        <% if favorite.contents.has_key?(@pet.id.to_s) %>
+            <%= button_to "Remove Pet from Favorites", "/favorites/#{@pet.id}", method: :delete %>
+          <% else %>
+            <%= button_to "Add Pet to Favorites", "/favorites/#{@pet.id}", method: :patch %> 
+        <% end %>
       </section>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
   post '/shelters/:shelter_id/pets', to: 'pets#create'
 
   patch '/favorites/:pet_id', to: 'favorites#update'
+  delete '/favorites/:pet_id', to: 'favorites#destroy'
 
   get 'shelters/:shelter_id/reviews/new', to:'reviews#new'
   post '/shelters/:shelter_id', to: 'reviews#create'

--- a/spec/features/favorites/add_favorite_spec.rb
+++ b/spec/features/favorites/add_favorite_spec.rb
@@ -23,18 +23,18 @@ describe "When a user adds a favorite" do
 
     click_button "Add Pet to Favorites"
     
-    expect(page).to have_content("Favorited Pets: 1")
+    expect(page).to have_content("Favorite Pets: 1")
     
     visit "/pets/#{pet2.id}"
 
     click_button "Add Pet to Favorites"
     
-    expect(page).to have_content("Favorited Pets: 2")
+    expect(page).to have_content("Favorite Pets: 2")
     
     visit "/pets/#{pet3.id}"
 
     click_button "Add Pet to Favorites"
 
-    expect(page).to have_content("Favorited Pets: 3")
+    expect(page).to have_content("Favorite Pets: 3")
   end
 end

--- a/spec/features/favorites/favorite_delete_spec.rb
+++ b/spec/features/favorites/favorite_delete_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe "After a user adds a favorite pet" do
+  it "displays a remove pet button instead of add favorite pet button" do
+
+    pet1 = create(:pet)
+
+    visit "/pets/#{pet1.id}" 
+
+    within("#pet-#{pet1.id}") do
+      click_button "Add Pet to Favorites"
+    end
+
+    expect(page).to have_button('Remove Pet from Favorites')
+  end 
+end 
+
+describe "After a user clicks to remove pet from favorites" do
+  it "deletes the pet from favorites" do
+
+    pet1 = create(:pet)
+
+    visit "/pets/#{pet1.id}" 
+
+    within("#pet-#{pet1.id}") do
+      click_button "Add Pet to Favorites"
+    end
+     
+    within("#pet-#{pet1.id}") do
+      click_button "Remove Pet from Favorites"
+    end
+
+    expect(page).to have_button('Add Pet to Favorites')
+    expect(page).to have_content("Favorite Pets: 0")
+  end 
+end


### PR DESCRIPTION
Remove ability to favorite a pet more than once

* Add a feature spec for removing favorite pets
* Add delete route and destroy action method
* Update pet show view to toggle between add pet to favorites or remove pets from favorite depending on if pet is already favorited

Fixed:
* ( "Favorited Pets") spec now passing
* When pets are deleted they are now deleted from favorites too