### PR TITLE
User story23

### DIFF
--- a/spec/features/applications/approve_multiple_spec.rb
+++ b/spec/features/applications/approve_multiple_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe "user creates application for more than one pet" do
   describe "visits application show page" do
-    xit "can approve any number of pets" do
+    it "can approve any number of pets" do
       pet1 = create(:pet)
       pet2 = create(:pet)
 
@@ -22,9 +22,9 @@ describe "user creates application for more than one pet" do
       within("#pet-#{pet2.id}") do
         click_link "Approve Application for Pet"
       end
-      binding.pry
-      expect(pet1.id.applications.approved_application).to eq(application1)
-      expect(pet2.id.applications.approved_application).to eq(application1)
+  
+      expect(pet1.applications.approved_application).to eq(application1)
+      expect(pet2.applications.approved_application).to eq(application1)
 
     end
   end

--- a/spec/features/applications/approve_multiple_spec.rb
+++ b/spec/features/applications/approve_multiple_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe "user creates application for more than one pet" do
   describe "visits application show page" do
-    it "can approve any number of pets" do
+    xit "can approve any number of pets" do
       pet1 = create(:pet)
       pet2 = create(:pet)
 
@@ -22,7 +22,7 @@ describe "user creates application for more than one pet" do
       within("#pet-#{pet2.id}") do
         click_link "Approve Application for Pet"
       end
-
+      binding.pry
       expect(pet1.id.applications.approved_application).to eq(application1)
       expect(pet2.id.applications.approved_application).to eq(application1)
 

--- a/spec/features/applications/approve_multiple_spec.rb
+++ b/spec/features/applications/approve_multiple_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe "user creates application for more than one pet" do
+  describe "visits application show page" do
+    it "can approve any number of pets" do
+      pet1 = create(:pet)
+      pet2 = create(:pet)
+
+      application1 = create(:application)
+
+      PetApplication.create!(application: application1, pet: pet1)
+      PetApplication.create!(application: application1, pet: pet2)
+
+      visit "/applications/#{application1.id}"
+
+      within("#pet-#{pet1.id}") do
+        click_link "Approve Application for Pet"
+      end
+
+      visit "/applications/#{application1.id}"
+
+      within("#pet-#{pet2.id}") do
+        click_link "Approve Application for Pet"
+      end
+
+      expect(pet1.id.applications.approved_application).to eq(application1)
+      expect(pet2.id.applications.approved_application).to eq(application1)
+
+    end
+  end
+end


### PR DESCRIPTION
-Add Use Can get approve to adopt more than one pet 

-Created approve_multiple_spec 
-All test passing 


-I do wonder if we are reading this user story wrong. Is it saying we should be able to click "Approve application for Pet" twice without being rerouted to a different page? Because if so, this may not be right. Clicking that button will not route us to a pets show page as opposed to staying on the same page. 